### PR TITLE
No longer resubscribe on every update

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function useDocumentVisibility() {
     return () => {
       window.removeEventListener('visibilitychange', handleVisChange);
     };
-  });
+  }, []);
 
   return documentVisibility;
 }


### PR DESCRIPTION
The current `useEffect` will subscribe and unsubscribe on every render. This change makes it so that it only creates the subscription on mount, and removes the subscription on unmount.

[Docs here](https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect)

---

This is similar to https://github.com/rehooks/window-size/pull/1