### PR TITLE
Default document visibility to true for SSR

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 let { useState, useEffect } = require('react');
 
 function getVisibility() {
+  if (typeof document === "undefined") return true;
   return document.visibilityState;
 }
 


### PR DESCRIPTION
In the case `getVisibility()` is run on SSR it will default document visibility to `true` to avoid breaking SSR.

Right now it breaks due document being undefined, I think it made sense to default to true.